### PR TITLE
docs: add decode-zhuyin to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ you can even use `npx` to view this list of `awesome-npx` tools:
 ### [workin-hard](https://github.com/jshemas/workinHard) - a clone of [hackertyper.com](http://hackertyper.com/)
 `npx workin-hard`
 
+### [decode-zhuyin](https://github.com/tpai/decode-zhuyin) - decode Chinese word to Zhuyin password
+`npx decode-zhuyin <text>`
+
 ## 📰 articles and resources
 - [Introducing npx: an npm package runner](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b)
 - write one and we'll link it here!


### PR DESCRIPTION
Zhuyin is a bunch of symbol for transliterating Chinese word, most of Taiwanese people choose one sentence or few words, and map the Zhuyin position of keyboard to get meaning less characters as their password which is hard to remember, so that's what `decode-zhuyin` does.

- [x] I have read & abide by the CONTRIBUTING.md and CODE_OF_CONDUCT.md guidelines and agree to license my contributions as CC0-1.0.

type of change
=====
- [x] adding a tool / package / resource
  - please keep items sorted alphabetically
- [ ] a minor correction (spelling, broken link, name change)
- [ ] re-organization (please discuss on an issue before hand!)
- [ ] other