### PR TITLE
Add hypertunnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ you can even use `npx` to view this list of `awesome-npx` tools:
 ### [hypertunnel](https://github.com/berstend/hypertunnel) - expose any local TCP/IP service on the internet
 `npx hypertunnel --port 8080`
 
-
 ### [json-server](https://github.com/typicode/json-server) - run a mock REST API server with JSON-based response configuration
 `npx json-server https://raw.githubusercontent.com/typicode/jsonplaceholder/master/data.json`
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ you can even use `npx` to view this list of `awesome-npx` tools:
 ### [http-server](https://github.com/indexzero/http-server) - run a static web server in your current directory
 `npx http-server`
 
+### [hypertunnel](https://github.com/berstend/hypertunnel) - expose any local TCP/IP service on the internet
+`npx hypertunnel --port 8080`
+
+
 ### [json-server](https://github.com/typicode/json-server) - run a mock REST API server with JSON-based response configuration
 `npx json-server https://raw.githubusercontent.com/typicode/jsonplaceholder/master/data.json`
 


### PR DESCRIPTION
Expose any local TCP/IP service on the internet

- [x] I have read & abide by the CONTRIBUTING.md and CODE_OF_CONDUCT.md guidelines and agree to license my contributions as CC0-1.0.

type of change
=====
- [x] adding a tool / package / resource
  - please keep items sorted alphabetically
- [ ] a minor correction (spelling, broken link, name change)
- [ ] re-organization (please discuss on an issue before hand!)
- [ ] other

additional notes
=====

hypertunnel is similar to localtunnel/ngrok but allows exposing any kind of TCP/IP service, not just http servers. :-)